### PR TITLE
IpcMain names cleanup

### DIFF
--- a/src/main/docker.ts
+++ b/src/main/docker.ts
@@ -10,37 +10,37 @@ const __dirname = path.dirname(__filename)
 export const DOCKER_MACOS_PATH = '/usr/local/bin/docker'
 
 export const init = async () => {
-  ipcMain.on('docker-ps', async event => {
+  ipcMain.on('docker.containers.info', async event => {
     try {
       const containers = getDockerContainers()
-      event.reply('docker-ps-response', containers)
+      event.reply('docker.containers.reply', containers)
     } catch (error: unknown) {
-      event.reply('docker-ps-error', { error })
+      event.reply('docker.containers.reply.error', { error })
     }
   })
 
-  ipcMain.on('docker-check-php-version', (event, args) => {
+  ipcMain.on('docker.php-version.info', (event, args) => {
     try {
       const result = checkPHPVersion(args.container_id)
-      event.reply('docker-check-php-version-response', result)
+      event.reply('docker.php-version.reply', result)
     } catch (error: unknown) {
-      event.reply('docker-check-php-version-error', { error })
+      event.reply('docker.php-version.reply.error', { error })
     }
   })
 
-  ipcMain.on('docker-install-phar-client', (event, args) => {
+  ipcMain.on('docker.copy-phar.execute', (event, args) => {
     try {
       const versionMatch = args.php_version.match(/^(\d+\.\d+)/)
       const phpVersion = versionMatch ? versionMatch[1] : null
 
       const result = installPharClient(phpVersion, args.container_id)
 
-      event.reply('docker-install-phar-client-response', {
+      event.reply('docker.copy-phar.reply', {
         container_id: args.container_id,
         phar_path: result,
       })
     } catch (error: unknown) {
-      event.reply('docker-install-phar-client-error', { error })
+      event.reply('docker.copy-phar.reply.error', { error })
     }
   })
 }

--- a/src/renderer/components/DockerTabConnection.vue
+++ b/src/renderer/components/DockerTabConnection.vue
@@ -31,7 +31,7 @@
     tabsStore.updateTab(currentTab)
   }
 
-  const handleDockerCheckPHPVersionResponse = (e: string) => {
+  const handleDockerPHPVersionReply = (e: string) => {
     if (tabsStore.current?.docker.enable) {
       connected.value = e.toString() !== ''
 
@@ -41,7 +41,7 @@
     connected.value = false
   }
 
-  const handleDockerCheckPHPVersionError = () => {
+  const handleDockerPHPVersionReplyError = () => {
     connected.value = false
   }
 
@@ -50,17 +50,17 @@
       return
     }
 
-    window.ipcRenderer.send('docker-check-php-version', {
+    window.ipcRenderer.send('docker.php-version.info', {
       container_id: props.tab.docker.container_id,
     })
 
-    window.ipcRenderer.on('docker-check-php-version-response', handleDockerCheckPHPVersionResponse)
-    window.ipcRenderer.on('docker-check-php-version-error', handleDockerCheckPHPVersionError)
+    window.ipcRenderer.on('docker.php-version.reply', handleDockerPHPVersionReply)
+    window.ipcRenderer.on('docker.php-version.reply.error', handleDockerPHPVersionReplyError)
   })
 
   onUnmounted(() => {
-    window.ipcRenderer.removeListener('docker-check-php-version-response', handleDockerCheckPHPVersionResponse)
-    window.ipcRenderer.removeListener('docker-check-php-version-error', handleDockerCheckPHPVersionError)
+    window.ipcRenderer.removeListener('docker.php-version.reply', handleDockerPHPVersionReply)
+    window.ipcRenderer.removeListener('docker.php-version.reply.error', handleDockerPHPVersionReplyError)
   })
 </script>
 

--- a/src/renderer/views/CodeView.vue
+++ b/src/renderer/views/CodeView.vue
@@ -83,7 +83,7 @@
     tabsStore.updateTab(tab.value)
   }
 
-  window.ipcRenderer.on('docker-install-phar-client-response', (e: PharPathResponse) => {
+  window.ipcRenderer.on('docker.copy-phar.reply', (e: PharPathResponse) => {
     e.container_id && dockerClients.value.push(e.container_id)
   })
 
@@ -95,7 +95,7 @@
 
     if (docker.enable) {
       if (!dockerClients.value.includes(container_id)) {
-        window.ipcRenderer.send('docker-install-phar-client', {
+        window.ipcRenderer.send('docker.copy-phar.execute', {
           php_version: php_version,
           container_id: container_id,
         })


### PR DESCRIPTION
Some suggestions for improving the names of ipcMain events 

**Sender**: `{classname}-{action}-{type}`  - types: info, execute
**Reply**: `{classname}-{action}-{type}` - types: reply, reply.error