### PR TITLE
feat: add Night Owl theme support

### DIFF
--- a/src/renderer/assets/editor-themes/night-owl.json
+++ b/src/renderer/assets/editor-themes/night-owl.json
@@ -1,0 +1,110 @@
+{
+  "base": "vs-dark",
+  "inherit": true,
+  "rules": [
+    {
+      "background": "011627",
+      "token": ""
+    },
+    {
+      "foreground": "637777",
+      "token": "comment"
+    },
+    {
+      "foreground": "ecc48d",
+      "token": "string"
+    },
+    {
+      "foreground": "d3423e",
+      "token": "constant.numeric"
+    },
+    {
+      "foreground": "82AAFF",
+      "token": "constant.language"
+    },
+    {
+      "foreground": "c792ea",
+      "token": "keyword"
+    },
+    {
+      "foreground": "c792ea",
+      "token": "storage"
+    },
+    {
+      "foreground": "c792ea",
+      "token": "storage.type"
+    },
+    {
+      "foreground": "ffcb8b",
+      "token": "entity.name.class"
+    },
+    {
+      "foreground": "c5e478",
+      "token": "entity.other.inherited-class"
+    },
+    {
+      "foreground": "82AAFF",
+      "token": "entity.name.function"
+    },
+    {
+      "foreground": "7fdbca",
+      "token": "entity.name.tag"
+    },
+    {
+      "foreground": "c5e478",
+      "token": "entity.other.attribute-name"
+    },
+    {
+      "foreground": "82AAFF",
+      "token": "support.function"
+    },
+    {
+      "foreground": "f8f8f0",
+      "background": "f92672",
+      "token": "invalid"
+    },
+    {
+      "foreground": "f8f8f0",
+      "background": "ae81ff",
+      "token": "invalid.deprecated"
+    },
+    {
+      "foreground": "82AAFF",
+      "token": "variable"
+    },
+    {
+      "foreground": "d6deeb",
+      "token": "punctuation.definition"
+    },
+    {
+      "foreground": "d6deeb",
+      "token": "text"
+    },
+    {
+      "foreground": "b48ead",
+      "token": "constant.color.other.rgb-value"
+    },
+    {
+      "foreground": "ebcb8b",
+      "token": "constant.character.escape"
+    },
+    {
+      "foreground": "8fbcbb",
+      "token": "variable.other.constant"
+    }
+  ],
+  "colors": {
+    "foreground": "#d6deeb",
+    "background": "#011627",
+    "backgroundLight": "#122d42",
+    "border": "#122d42",
+    "editor.background": "#011627",
+    "editor.foreground": "#d6deeb",
+    "editor.selectionBackground": "#1d3b53",
+    "editor.lineHighlightBackground": "#0003",
+    "editorCursor.foreground": "#80a4c2",
+    "editorWhitespace.foreground": "#2e2040",
+    "editorIndentGuide.activeBackground": "#c792ea",
+    "editor.selectionHighlightBorder": "#222218"
+  }
+}

--- a/src/renderer/editor.ts
+++ b/src/renderer/editor.ts
@@ -4,6 +4,7 @@ import drakulaTheme from './assets/editor-themes/dracula.json'
 import monokaiTheme from './assets/editor-themes/monokai.json'
 import githubLightTheme from './assets/editor-themes/github-light.json'
 import catppuccinTheme from './assets/editor-themes/catppuccin.json'
+import nightOwlTheme from './assets/editor-themes/night-owl.json'
 
 // Explicitly type the themes
 const typedNordTheme = nordTheme as monaco.editor.IStandaloneThemeData
@@ -11,6 +12,7 @@ const typedDrakulaTheme = drakulaTheme as monaco.editor.IStandaloneThemeData
 const typedMonokaiTheme = monokaiTheme as monaco.editor.IStandaloneThemeData
 const typedGithubLightTheme = githubLightTheme as monaco.editor.IStandaloneThemeData
 const typedCatppuccinTheme = catppuccinTheme as monaco.editor.IStandaloneThemeData
+const typedNightOwlTheme = nightOwlTheme as monaco.editor.IStandaloneThemeData
 
 export const installThemes = () => {
   monaco.editor.defineTheme('nord', typedNordTheme)
@@ -18,6 +20,7 @@ export const installThemes = () => {
   monaco.editor.defineTheme('monokai', typedMonokaiTheme)
   monaco.editor.defineTheme('github-light', typedGithubLightTheme)
   monaco.editor.defineTheme('catppuccin', typedCatppuccinTheme)
+  monaco.editor.defineTheme('night-owl', typedNightOwlTheme)
 }
 
 export const installPHPLanguage = () => {

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -5,6 +5,7 @@ import drakulaTheme from '../assets/editor-themes/dracula.json'
 import monokaiTheme from '../assets/editor-themes/monokai.json'
 import githubLightTheme from '../assets/editor-themes/github-light.json'
 import catppuccinTheme from '../assets/editor-themes/catppuccin.json'
+import nightOwlTheme from '../assets/editor-themes/night-owl.json'
 import { computed, ref } from 'vue'
 import { Settings } from '../../types/settings.type.ts'
 
@@ -14,6 +15,7 @@ const typedDrakulaTheme = drakulaTheme as monaco.editor.IStandaloneThemeData
 const typedMonokaiTheme = monokaiTheme as monaco.editor.IStandaloneThemeData
 const typedGithubLightTheme = githubLightTheme as monaco.editor.IStandaloneThemeData
 const typedCatppuccinTheme = catppuccinTheme as monaco.editor.IStandaloneThemeData
+const typedNightOwlTheme = nightOwlTheme as monaco.editor.IStandaloneThemeData
 
 const themeColors: { [key: string]: { [key: string]: string } } = {
   'nord': nordTheme.colors,
@@ -21,6 +23,7 @@ const themeColors: { [key: string]: { [key: string]: string } } = {
   'monokai': monokaiTheme.colors,
   'github-light': githubLightTheme.colors,
   'catppuccin': catppuccinTheme.colors,
+  'night-owl': nightOwlTheme.colors,
 }
 
 export const useSettingsStore = defineStore('settings', () => {
@@ -65,6 +68,7 @@ export const useSettingsStore = defineStore('settings', () => {
     monaco.editor.defineTheme('monokai', typedMonokaiTheme)
     monaco.editor.defineTheme('github-light', typedGithubLightTheme)
     monaco.editor.defineTheme('catppuccin', typedCatppuccinTheme)
+    monaco.editor.defineTheme('night-owl', typedNightOwlTheme)
   }
 
   return { settings, themes, setSettings, update, colors, defineEditorThemes }


### PR DESCRIPTION
I very much enjoy using TweakPHP, it extends the experience of php tinker beyond the terminal experience and I love it ❤️.

I also enjoy using the Night Owl theme, I use it for everything, my warp terminal, my vscode, gosh even in chrome it self!

I thought I'd complete this setup and add the Night Owl theme to TweakPHP and It looks beautiful

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/3c4c9105-812e-450d-a3b6-64856a95e4e5" />

Thanks for considering my PR.
 