### PR TITLE
[draft] Add LSP status management and reconnect functionality

### DIFF
--- a/src/renderer/components/icons/ArrowPathRoundedSquare.vue
+++ b/src/renderer/components/icons/ArrowPathRoundedSquare.vue
@@ -1,0 +1,5 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+  </svg>
+</template>

--- a/src/renderer/components/icons/CheckCircle.vue
+++ b/src/renderer/components/icons/CheckCircle.vue
@@ -1,0 +1,5 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  </svg>
+</template>

--- a/src/renderer/components/icons/ExclamationCircle.vue
+++ b/src/renderer/components/icons/ExclamationCircle.vue
@@ -1,0 +1,5 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+  </svg>
+</template>

--- a/src/renderer/stores/lsp.ts
+++ b/src/renderer/stores/lsp.ts
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type LspStatus = 'connected' | 'connecting' | 'disconnected'
+
+export const useLspStore = defineStore('lsp', () => {
+  const status = ref<LspStatus>('disconnected')
+
+  function setStatus(newStatus: LspStatus) {
+    status.value = newStatus
+  }
+
+  function setConnected() {
+    status.value = 'connected'
+  }
+
+  function setConnecting() {
+    status.value = 'connecting'
+  }
+
+  function setDisconnected() {
+    status.value = 'disconnected'
+  }
+
+  return { status, setStatus, setConnected, setConnecting, setDisconnected }
+})

--- a/src/renderer/views/CodeView.vue
+++ b/src/renderer/views/CodeView.vue
@@ -2,7 +2,8 @@
   import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
   import { useExecuteStore } from '../stores/execute'
   import { useTabsStore } from '../stores/tabs'
-  import { useVaporStore } from '../stores/vapor.ts'
+  import { useVaporStore } from '../stores/vapor'
+  import { useLspStore } from '../stores/lsp'
   import Container from '../components/Container.vue'
   import events from '../events'
   import { useSettingsStore } from '../stores/settings'
@@ -15,12 +16,16 @@
   import 'splitpanes/dist/splitpanes.css'
   import StackedOutput from '../components/StackedOutput.vue'
   import { useLodaersStore } from '../stores/loaders'
+  import ExclamationCircle from '@/components/icons/ExclamationCircle.vue'
+  import ArrowPathRoundedSquare from '@/components/icons/ArrowPathRoundedSquare.vue'
+  import CheckCircle from '@/components/icons/CheckCircle.vue'
 
   const settingsStore = useSettingsStore()
   const executeStore = useExecuteStore()
   const vaporStore = useVaporStore()
   const tabsStore = useTabsStore()
-  const codeEditor = ref(null)
+  const lspStore = useLspStore()
+  const codeEditor = ref<InstanceType<typeof Editor> | null>(null)
   const resultEditor = ref<InstanceType<typeof Editor> | null>(null)
   const loadersStore = useLodaersStore()
 
@@ -50,6 +55,23 @@
     const output = [...tab.value.result].reverse().find(item => item.output.trim() !== '')
     return output ? output.output : ''
   })
+
+  const lspStatusTooltip = computed(() => {
+    switch (lspStore.status) {
+      case 'connected':
+        return 'LSP Connected'
+      case 'connecting':
+        return 'LSP Connecting...'
+      case 'disconnected':
+        return 'LSP Disconnected (Click to reconnect)'
+    }
+  })
+
+  const handleLspReconnect = () => {
+    if (lspStore.status === 'disconnected' && codeEditor.value) {
+      codeEditor.value.reconnectLsp()
+    }
+  }
 
   const vaporRequestEnvironmentTab = () => {
     if (!tabsStore.current?.id || !tabsStore.current?.path) {
@@ -316,6 +338,28 @@
         backgroundColor: settingsStore.colors.background,
       }"
     >
+      <div
+        class="flex items-center ml-2"
+        :class="{ 'cursor-pointer': lspStore.status === 'disconnected' }"
+        v-tippy="lspStatusTooltip"
+        @click="handleLspReconnect"
+      >
+        <template v-if="lspStore.status === 'connected'">
+          <div class="flex items-center justify-center bg-green-500 rounded-full size-4">
+            <CheckCircle class="size-4 shrink-0 text-green-800" />
+          </div>
+        </template>
+        <template v-else-if="lspStore.status === 'connecting'">
+          <div class="flex items-center justify-center bg-yellow-500 rounded-full size-4">
+            <ArrowPathRoundedSquare class="w-3 h-3 shrink-0 text-yellow-800 animate-spin" />
+          </div>
+        </template>
+        <template v-else-if="lspStore.status === 'disconnected'">
+          <div class="flex items-center justify-center bg-red-500 rounded-full size-4">
+            <ExclamationCircle class="size-4 shrink-0 text-red-800" />
+          </div>
+        </template>
+      </div>
       <div class="px-2 flex gap-1 w-1/2 items-center">
         <div class="whitespace-nowrap">PHP {{ tab.info.php_version }}</div>
       </div>


### PR DESCRIPTION
Introduces a visual indicator in the CodeView status bar to
show the connection status to the Language Server (LSP).

The indicator changes colour and icon depending on the status:
- Green: Connected
- Yellow: Connecting/reconnecting
- Red: Disconnected

When the status is disconnected (red), the user can click on the icon
to manually attempt to re-establish the connection.

Status management has been centralised via a new Pinia store
(`useLspStore`) to decouple the logic from the UI.