### PR TITLE
Handle php executable in settings

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -4,6 +4,7 @@ import * as lsp from './lsp/index'
 import { app, ipcMain } from 'electron'
 import { Settings } from '../types/settings.type'
 import os from 'os'
+import { isWindows } from './system/platform.ts'
 
 const homeDir = os.homedir()
 
@@ -36,6 +37,22 @@ const defaultSettings: Settings = {
 
 export const init = async () => {
   ipcMain.on('settings.store', async (_event: any, data: Settings) => {
+    try {
+      const phpExecutable = isWindows() ? 'php.exe' : 'php'
+
+      if (fs.existsSync(data.php) && fs.lstatSync(data.php).isDirectory()) {
+        let potentialPath = path.join(data.php, phpExecutable)
+
+        if (fs.existsSync(potentialPath)) {
+          data.php = potentialPath
+
+          _event.sender.send('settings.php-located', potentialPath)
+        }
+      }
+    } catch (err) {
+      // Ignore errors - perhaps path no longer exists or has been changed
+    }
+
     setSettings(data)
     await lsp.init()
   })

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -52,7 +52,6 @@ const handlePhpExecutable = (_event: any, data: Settings) => {
 
       if (fs.existsSync(potentialPath)) {
         data.php = potentialPath
-
         _event.sender.send('settings.php-located', potentialPath)
       }
     }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -37,23 +37,29 @@ const defaultSettings: Settings = {
 
 export const init = async () => {
   ipcMain.on('settings.store', async (_event: any, data: Settings) => {
-    try {
-      if (fs.existsSync(data.php) && fs.lstatSync(data.php).isDirectory()) {
-        let phpExecutable = isWindows() ? 'php.exe' : 'php'
-        let potentialPath = path.join(data.php, phpExecutable)
-
-        if (fs.existsSync(potentialPath)) {
-          data.php = potentialPath
-          _event.sender.send('settings.php-located', potentialPath)
-        }
-      }
-    } catch (err) {
-      // Ignore errors - perhaps path no longer exists or has been changed
-    }
-
-    setSettings(data)
+    let returnedData = handlePhpExecutable(_event, data)
+    setSettings(returnedData)
     await lsp.init()
   })
+}
+
+const handlePhpExecutable = (_event: any, data: Settings) => {
+  try {
+    const phpExecutable = isWindows() ? 'php.exe' : 'php'
+
+    if (fs.existsSync(data.php) && fs.lstatSync(data.php).isDirectory()) {
+      let potentialPath = path.join(data.php, phpExecutable)
+
+      if (fs.existsSync(potentialPath)) {
+        data.php = potentialPath
+
+        _event.sender.send('settings.php-located', potentialPath)
+      }
+    }
+  } catch (err) {
+    // Ignore errors — e.g., path no longer exists or has been changed
+  }
+  return data
 }
 
 export const setSettings = async (data: Settings) => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -37,28 +37,27 @@ const defaultSettings: Settings = {
 
 export const init = async () => {
   ipcMain.on('settings.store', async (_event: any, data: Settings) => {
-    let returnedData = handlePhpExecutable(_event, data)
-    setSettings(returnedData)
+    data.php = handlePhpExecutable(_event, data.php)
+    setSettings(data)
     await lsp.init()
   })
 }
 
-const handlePhpExecutable = (_event: any, data: Settings) => {
+const handlePhpExecutable = (_event: any, phpPath: string) => {
   try {
-    const phpExecutable = isWindows() ? 'php.exe' : 'php'
-
-    if (fs.existsSync(data.php) && fs.lstatSync(data.php).isDirectory()) {
-      let potentialPath = path.join(data.php, phpExecutable)
+    if (fs.existsSync(phpPath) && fs.lstatSync(phpPath).isDirectory()) {
+      const phpExecutable = isWindows() ? 'php.exe' : 'php'
+      let potentialPath = path.join(phpPath, phpExecutable)
 
       if (fs.existsSync(potentialPath)) {
-        data.php = potentialPath
+        phpPath = potentialPath
         _event.sender.send('settings.php-located', potentialPath)
       }
     }
   } catch (err) {
-    // Ignore errors — e.g., path no longer exists or has been changed
+    // Ignore errors as path may no longer exist or has been changed etc..
   }
-  return data
+  return phpPath
 }
 
 export const setSettings = async (data: Settings) => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -38,14 +38,12 @@ const defaultSettings: Settings = {
 export const init = async () => {
   ipcMain.on('settings.store', async (_event: any, data: Settings) => {
     try {
-      const phpExecutable = isWindows() ? 'php.exe' : 'php'
-
       if (fs.existsSync(data.php) && fs.lstatSync(data.php).isDirectory()) {
+        let phpExecutable = isWindows() ? 'php.exe' : 'php'
         let potentialPath = path.join(data.php, phpExecutable)
 
         if (fs.existsSync(potentialPath)) {
           data.php = potentialPath
-
           _event.sender.send('settings.php-located', potentialPath)
         }
       }

--- a/src/renderer/views/settings/GeneralSettings.vue
+++ b/src/renderer/views/settings/GeneralSettings.vue
@@ -4,11 +4,19 @@
   import { useSettingsStore } from '../../stores/settings'
   import SelectInput from '../../components/SelectInput.vue'
   import TextInput from '../../components/TextInput.vue'
-  import { ref } from 'vue'
+  import { ref, onMounted } from 'vue'
   import UpdateApp from '../../components/UpdateApp.vue'
 
   const saved = ref(false)
   const settingsStore = useSettingsStore()
+
+  onMounted(() => {
+    window.ipcRenderer.on('settings.php-located', updatePhpSetting)
+  })
+
+  const updatePhpSetting = (newPhpSetting: string) => {
+    settingsStore.settings.php = newPhpSetting
+  }
 
   const saveSettings = () => {
     saved.value = true


### PR DESCRIPTION
When I setup the app it was asking for a php path in the settings. 

I gave it C:\php, but it still wasn't working. I then realised it needed the executable path. 

This PR adds a helpful feature, where if a user enters the directory, but not the executable path it will link it up - which may save confusion 😃 

Here is what I mean: 
(Basically if you enter a correct php dir, it'll link up the executable)

https://github.com/user-attachments/assets/54ec4276-63e9-4461-985d-9b32882edd1d

