### PR TITLE
fix: passphrase stored to SSH connection

### DIFF
--- a/src/renderer/stores/ssh.ts
+++ b/src/renderer/stores/ssh.ts
@@ -57,6 +57,7 @@ const normalize = (connection: any): any => {
     auth_type: connection.auth_type ?? 'password',
     password: connection.password ?? '',
     privateKey: connection.privateKey ?? '',
+    passphrase: connection.passphrase ?? '',
     path: connection.path ?? '',
     php: connection.php ?? '',
     client_path: connection.phar_client ? connection.phar_client : connection.client_path,


### PR DESCRIPTION
The passphrase was stored on connection ssh, but on new instances always was empty, now works correctly 