### PR TITLE
chore: align concurrently dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "adm-zip": "^0.5.16",
         "autoprefixer": "^10.4.19",
         "bufferutil": "^4.0.8",
-        "concurrently": "^9.1.2",
+        "concurrently": "^9.2.4",
         "dotenv": "^16.4.7",
         "electron": "^41.1.1",
         "electron-builder": "^26.8.1",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "adm-zip": "^0.5.16",
     "autoprefixer": "^10.4.19",
     "bufferutil": "^4.0.8",
-    "concurrently": "^9.1.2",
+    "concurrently": "^9.2.4",
     "dotenv": "^16.4.7",
     "electron": "^41.1.1",
     "electron-builder": "^26.8.1",


### PR DESCRIPTION
Aligns the declared concurrently range with the already-resolved 9.2.4 version. Supersedes Dependabot PR #230; PRs #225 through #229 are already absorbed or no longer applicable.